### PR TITLE
Remove react hooks from contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ There are a few topics that we wanted to provide some information on, but weren'
 - [Providers and Signers](#providers-and-signers)
 - [BigNumbers](#bignumbers)
 - [ABI](#abi)
-- [React Hooks](#react-hooks)
 - [ERC20 Approval Flow](#erc20-approval-flow)
 
 ## Providers and Signers


### PR DESCRIPTION
In lesson one of the sophomore course (Just Enough React (and Next.js)) react hooks are already covered in some detail, I can see the detail was removed here  in commit #7 so here im removing it from the top of the page